### PR TITLE
Updating publish workflow to work with release drafter

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -1,8 +1,8 @@
 name: PyPi Publish
 on:
-  push:
-    tags:
-      - v*.*.*
+  release:
+    types:
+    - published
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Workflow doesn't run on tag push when using release-drafter so changing the trigger to a release publish.