### PR TITLE
Update python-version on .github/workflows/pypi-publish.yaml

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install Poetry and add to path
       run: |
         curl -sSL https://install.python-poetry.org/install-poetry.py | python -


### PR DESCRIPTION
[issue#418](https://github.com/sanders41/sas7bdat-converter/issues/418)
Hi [sanders41](https://github.com/sanders41), do you mean on [.github/workflows/pypi-publish.yaml](https://github.com/sanders41/sas7bdat-converter/blob/main/.github/workflows/pypi-publish.yaml) ? If yes, it should be updated on this PR